### PR TITLE
define opaque struct types as pointers

### DIFF
--- a/src/vulkan-spec/constants.lisp
+++ b/src/vulkan-spec/constants.lisp
@@ -75,12 +75,12 @@
     "IDirectFB"
     "IDirectFBSurface"
     "CAMetalLayer"
-    "Display"))
+    "Display"
+    "wl_display"
+    "wl_surface"))
 
 (defparameter *opaque-struct-types*
-  '("wl_display"
-    "wl_surface"
-    "SECURITY_ATTRIBUTES"
+  '("SECURITY_ATTRIBUTES"
     "_screen_context"  ;; added in v1.2.171
     "_screen_window" ;; added in v1.2.171
     ;; all StdVideo-structs have been added in v1.2.175


### PR DESCRIPTION
Should fix the issue brought up in https://github.com/JolifantoBambla/vk/pull/13

Actually all of the `*opaque-struct-types*` should be just be pointers as `vk` can't fill them without a spec anyway. Video encoding / decoding structs are defined in `vk_video.xml` starting from v1.3 though, so they should get defined as pointers in v1.1 & v1.2 but as structs (with a definition parsed from the new xml) in v1.3 and higher.